### PR TITLE
Add textAlign config option with support for 'left' and 'center'

### DIFF
--- a/MMM-AnyList.css
+++ b/MMM-AnyList.css
@@ -5,3 +5,13 @@
   line-height: 25px;
   color: lightgray;
 }
+
+.anylist .leftAligned td,
+.anylist .leftAligned th {
+  text-align: left;
+}
+
+.anylist .centerAligned td,
+.anylist .centerAligned th {
+  text-align: center;
+}

--- a/MMM-AnyList.js
+++ b/MMM-AnyList.js
@@ -10,7 +10,8 @@ Module.register('MMM-AnyList', {
 		highlightColor: 'darkslategrey',
 		trimText: true,
 		showCategories: true,
-		showQuantities: true
+		showQuantities: true,
+		textAlign: 'center'
 	},
 
 	start() {
@@ -41,16 +42,26 @@ Module.register('MMM-AnyList', {
 		const tableContainer = document.createElement('table');
 		tableContainer.className = 'small';
 
+		if (this.config.textAlign === 'left') {
+			tableContainer.className += ' leftAligned';
+		}
+
+		if (this.config.textAlign === 'center') {
+			tableContainer.className += ' centerAligned';
+		}
+
 		let category = '';
 
 		// Add items to container
 		this.list.items.forEach((item, i) => {
 			// Create header cell if current item is in a different category than the previous item
 			if (item.categoryMatchId !== category && this.config.showCategories) {
-				const header = document.createElement('th');
+				const headerRow = document.createElement('tr');
 
-				const toUpper =
-          item.categoryMatchId[0].toUpperCase() + item.categoryMatchId.slice(1); // Make first letter upper case
+				const header = document.createElement('th');
+				headerRow.append(header);
+
+				const toUpper = item.categoryMatchId[0].toUpperCase() + item.categoryMatchId.slice(1); // Make first letter upper case
 				const format = toUpper.replace(/-/g, ' '); // Replace hyphens with spaces
 
 				if (i > 0) {
@@ -62,7 +73,8 @@ Module.register('MMM-AnyList', {
 					1;
 
 				header.innerHTML = format;
-				tableContainer.append(header);
+
+				tableContainer.append(headerRow);
 
 				category = item.categoryMatchId;
 			}
@@ -88,8 +100,8 @@ Module.register('MMM-AnyList', {
 
 			if (
 				i % 2 === 0 &&
-        this.config.highlightAlternateRows &&
-        !this.config.showCategories
+		this.config.highlightAlternateRows &&
+		!this.config.showCategories
 			) {
 				itemRow.style.backgroundColor = this.config.highlightColor;
 			}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Activate the module by adding it to the config.js file as shown below.
     animationSpeed: 2000,
     trimText: true,
     showCategories: true,
-    showQuantities: true
+    showQuantities: true,
+    textAlign: 'center'
   }
 }
 ```
@@ -58,5 +59,6 @@ The entry in `config.js` can include the following options:
 |`trimText`|Trim any items more than 25 characters long to save space|`true`|`true / false`|
 |`showCategories`|Use item categories as table headers|`true`|`true / false`|
 |`showQuantities`|Show the quantity of each item from your list|`true`|`true / false`|
+|`textAlign`|Choose whether the items in the list are left-aligned or centered|`'center'`|`'center' / 'left'` 
 
 


### PR DESCRIPTION
# What
- Adds a new config option: `textAlign` that supports `'left'` and `'center'`.
- Updates readme to document the change
- Also added a `<tr>` tag around the `<th>` elements so they're not direct children of the `<table>` element, per the MDN spec (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#technical_summary)

Resolves #31

## Hacktoberfest!
If you do decide to merge this puppy 🐶 , it would help out my Hacktoberfest stats if you added the `HACKTOBERFEST-ACCEPTED` label to this PR 👍🏻 