### PR TITLE
Error messages from the AnyList client are surfaced in the UI for observability and troubleshooting

### DIFF
--- a/MMM-AnyList.js
+++ b/MMM-AnyList.js
@@ -28,6 +28,13 @@ Module.register('MMM-AnyList', {
 		const wrapper = document.createElement('div');
 		wrapper.className = 'anylist';
 
+		if (this.error) {
+			// If an error was sent from the node_helper, display it in the UI
+			wrapper.innerHTML = `${this.error}`;
+			wrapper.className = 'small';
+			return wrapper;
+		}
+
 		if (!this.list) {
 			// Data hasn't been loaded yet, return
 			wrapper.innerHTML = 'Loading …';
@@ -121,6 +128,8 @@ Module.register('MMM-AnyList', {
 	socketNotificationReceived(notification, payload) {
 		if (notification === 'LIST_DATA' && payload.name === this.config.list) {
 			// Update local data
+			this.error = null;
+
 			let items = payload.items;
 
 			if (this.config.onlyShowUnchecked) {
@@ -148,6 +157,9 @@ Module.register('MMM-AnyList', {
 			this.list = list;
 
 			// Update display
+			this.updateDom(this.config.animationSpeed);
+		} else if (notification === 'ANYLIST_ERROR') {
+			this.error = payload;
 			this.updateDom(this.config.animationSpeed);
 		}
 	},

--- a/node_helper.js
+++ b/node_helper.js
@@ -10,7 +10,7 @@ module.exports = NodeHelper.create({
 
 		// Limit concurrency, otherwise we get errors when
 		// logging in.
-		this.queue = queue(async (task, callback) => {
+		this.queue = queue(async task => {
 			const {notification, payload} = task;
 
 			if (notification === 'INIT') {
@@ -28,8 +28,6 @@ module.exports = NodeHelper.create({
 
 				this.sendSocketNotification('LIST_DATA', this.anylist.getListByName(list));
 			}
-
-			callback();
 		}, 1);
 
 		this.queue.error((err, task) => {

--- a/node_helper.js
+++ b/node_helper.js
@@ -4,10 +4,12 @@ const queue = require('async/queue');
 
 module.exports = NodeHelper.create({
 	start() {
+		const self = this;
+
 		console.log(`Starting node helper: ${this.name}`);
 
 		// Limit concurrency, otherwise we get errors when
-		// loging in.
+		// logging in.
 		this.queue = queue(async (task, callback) => {
 			const {notification, payload} = task;
 
@@ -29,6 +31,12 @@ module.exports = NodeHelper.create({
 
 			callback();
 		}, 1);
+
+		this.queue.error((err, task) => {
+			const message = `AnyList module experienced an error while processing a ${task.notification} notification: ${err}`;
+			console.error(message);
+			self.sendSocketNotification('ANYLIST_ERROR', message);
+		});
 	},
 
 	async socketNotificationReceived(notification, payload) {


### PR DESCRIPTION
## What
- Errors from the AnyList client (i.e. 401 Unauthorized) are surfaced in the MagicMirror UI to make troubleshooting a breeze.

## Why
- This is expected to assist in troubleshooting nebulous issues like #22, #25, and #30
- ...and also for those Hacktoberfest stats!  😉  If you decide to merge, add that `HACKTOBERFEST-ACCEPTED` label so I can get those endorphines


This is what the error messages will look like now:

<img width="640" alt="image" src="https://github.com/codetheweb/MMM-AnyList/assets/189640/6317bf68-678f-4bac-843e-0bed313179d3">

## Testing
- You can force an error by configuring a MagicMirror instance with this module using an invalid username/password. Confirm that the error message from the AnyList client is displayed in the server logs and in the MagicMirror UI.
- Now provide valid credentials and confirm that the module still displays the expected list properly.
